### PR TITLE
Add set mode to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ python -m aiocomfoconnect register --host 192.168.1.213
 
 $ python -m aiocomfoconnect set-speed away --host 192.168.1.213
 $ python -m aiocomfoconnect set-speed low --host 192.168.1.213
+$ python -m aiocomfoconnect set-mode auto --host 192.168.1.213
 $ python -m aiocomfoconnect set-speed medium --host 192.168.1.213
 $ python -m aiocomfoconnect set-speed high --host 192.168.1.213
 
@@ -140,7 +141,7 @@ if __name__ == "__main__":
 
 ### Decode network traffic
 
-You can use the `scripts/decode_pcap.py` file to decode network traffic between the Mobile App and the ComfoConnect LAN C. 
+You can use the `scripts/decode_pcap.py` file to decode network traffic between the Mobile App and the ComfoConnect LAN C.
 Make sure that the first TCP session in the capture is the connection between the bridge and the app. It's therefore recommended to start the capture before you open the app.
 
 ```shell

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -91,8 +91,8 @@ indicates the length of the `op` field, the rest of the data contains the `msg`.
 | Field                 | Data                                 | Remark                                                |
 |-----------------------|--------------------------------------|-------------------------------------------------------|
 | length (32 bit)       | `0x0000004f`                         | Length of the whole message excluding this field      |
-| src (12 bytes)        | `0xaf154804169043898d2da77148f886be` |                                                       |
-| dst (12 bytes)        | `0x0000000000251010800170b3d54264b4` |                                                       |
+| src (16 bytes)        | `0xaf154804169043898d2da77148f886be` |                                                       |
+| dst (16 bytes)        | `0x0000000000251010800170b3d54264b4` |                                                       |
 | op_length (16 bit     | `0x0004`                             | Length of the `op` message                            |
 | op (variable length)  | `0x08342002`                         | Message with type `GatewayOperation`                  |
 | msg (variable length) | `...`                                | Message with type that is stated in `op.type`         |


### PR DESCRIPTION
First of all - thanks for the great repository and research of the protocol!

I want to add cli option to set the mode - i am using that in home automation (node-red) to basically jump to the manual mode for a moment (to change the speed) and then to return to auto mode. I haven't use python for years hope all here is correct , would love to hear any suggestions.

I did some research by looking inside the android app apk file. Code is really obfuscated there but these are some minor findings that might be interesting:

* the magic `0x0a00` number is basically a `DiscoveryOperation` with empty object set to `searchGatewayRequest` returned from protocol buffers
* UUIDs are generated from standard 128bytes UUID, the most and the least significant 8 bytes are concatenated together to create 16byte ID used in communication. (I fixed the docs saying it is 12 bytes)