### PR TITLE
Parse airflow constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ python -m aiocomfoconnect set-speed high --host 192.168.1.213
 
 $ python -m aiocomfoconnect show-sensors --host 192.168.1.213
 $ python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213
+$ python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213 -f
 
 $ python -m aiocomfoconnect get-property --host 192.168.1.213 1 1 8 9  # Unit 0x01, SubUnit 0x01, Property 0x08, Type STRING. See PROTOCOL-RMI.md
 ```

--- a/aiocomfoconnect/sensors.py
+++ b/aiocomfoconnect/sensors.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Dict
 
+from .util import calculate_airflow_constraint
 from .const import (
     TYPE_CN_BOOL,
     TYPE_CN_INT16,
     TYPE_CN_UINT8,
     TYPE_CN_UINT16,
     TYPE_CN_UINT32,
+    TYPE_CN_INT64,
 )
 
 # Sensors
@@ -74,6 +76,7 @@ SENSOR_TEMPERATURE_OUTDOOR = 276
 SENSOR_TEMPERATURE_SUPPLY = 221
 SENSOR_UNIT_AIRFLOW = 224
 SENSOR_UNIT_TEMPERATURE = 208
+SENSOR_AIRFLOW_CONSTRAINTS = 230
 
 UNIT_WATT = "W"
 UNIT_KWH = "kWh"
@@ -148,6 +151,7 @@ SENSORS: Dict[int, Sensor] = {
     SENSOR_FAN_SPEED_MODE_MODULATED: Sensor("Fan Speed (modulated)", None, 226, TYPE_CN_UINT16),
     SENSOR_BYPASS_STATE: Sensor("Bypass State", UNIT_PERCENT, 227, TYPE_CN_UINT8),
     SENSOR_FROSTPROTECTION_UNBALANCE: Sensor("frostprotection_unbalance", None, 228, TYPE_CN_UINT8),
+    SENSOR_AIRFLOW_CONSTRAINTS: Sensor("Airflow constraints", None, 230, TYPE_CN_INT64, lambda x: calculate_airflow_constraint(x)),
     SENSOR_TEMPERATURE_EXTRACT: Sensor("Extract Air Temperature", UNIT_CELCIUS, 274, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_EXHAUST: Sensor("Exhaust Air Temperature", UNIT_CELCIUS, 275, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_OUTDOOR: Sensor("Outdoor Air Temperature", UNIT_CELCIUS, 276, TYPE_CN_INT16, lambda x: x / 10),

--- a/aiocomfoconnect/sensors.py
+++ b/aiocomfoconnect/sensors.py
@@ -151,7 +151,7 @@ SENSORS: Dict[int, Sensor] = {
     SENSOR_FAN_SPEED_MODE_MODULATED: Sensor("Fan Speed (modulated)", None, 226, TYPE_CN_UINT16),
     SENSOR_BYPASS_STATE: Sensor("Bypass State", UNIT_PERCENT, 227, TYPE_CN_UINT8),
     SENSOR_FROSTPROTECTION_UNBALANCE: Sensor("frostprotection_unbalance", None, 228, TYPE_CN_UINT8),
-    SENSOR_AIRFLOW_CONSTRAINTS: Sensor("Airflow constraints", None, 230, TYPE_CN_INT64, lambda x: calculate_airflow_constraints(x)),
+    SENSOR_AIRFLOW_CONSTRAINTS: Sensor("Airflow constraints", None, 230, TYPE_CN_INT64, calculate_airflow_constraints),
     SENSOR_TEMPERATURE_EXTRACT: Sensor("Extract Air Temperature", UNIT_CELCIUS, 274, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_EXHAUST: Sensor("Exhaust Air Temperature", UNIT_CELCIUS, 275, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_OUTDOOR: Sensor("Outdoor Air Temperature", UNIT_CELCIUS, 276, TYPE_CN_INT16, lambda x: x / 10),

--- a/aiocomfoconnect/sensors.py
+++ b/aiocomfoconnect/sensors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Dict
 
-from .util import calculate_airflow_constraint
+from .util import calculate_airflow_constraints
 from .const import (
     TYPE_CN_BOOL,
     TYPE_CN_INT16,
@@ -151,7 +151,7 @@ SENSORS: Dict[int, Sensor] = {
     SENSOR_FAN_SPEED_MODE_MODULATED: Sensor("Fan Speed (modulated)", None, 226, TYPE_CN_UINT16),
     SENSOR_BYPASS_STATE: Sensor("Bypass State", UNIT_PERCENT, 227, TYPE_CN_UINT8),
     SENSOR_FROSTPROTECTION_UNBALANCE: Sensor("frostprotection_unbalance", None, 228, TYPE_CN_UINT8),
-    SENSOR_AIRFLOW_CONSTRAINTS: Sensor("Airflow constraints", None, 230, TYPE_CN_INT64, lambda x: calculate_airflow_constraint(x)),
+    SENSOR_AIRFLOW_CONSTRAINTS: Sensor("Airflow constraints", None, 230, TYPE_CN_INT64, lambda x: calculate_airflow_constraints(x)),
     SENSOR_TEMPERATURE_EXTRACT: Sensor("Extract Air Temperature", UNIT_CELCIUS, 274, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_EXHAUST: Sensor("Exhaust Air Temperature", UNIT_CELCIUS, 275, TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_TEMPERATURE_OUTDOOR: Sensor("Outdoor Air Temperature", UNIT_CELCIUS, 276, TYPE_CN_INT16, lambda x: x / 10),

--- a/aiocomfoconnect/util.py
+++ b/aiocomfoconnect/util.py
@@ -59,64 +59,66 @@ def can_to_pdo(can, node_id=1):
     return (int(can, 16) - 0x40 - node_id) >> 14
 
 
-def calculate_airflow_constraint(value):
-    """Calculate the airflow constraint based on the bitshift value."""
+def calculate_airflow_constraints(value):
+    """Calculate the airflow constraints based on the bitshift value."""
     bits = uint_to_bits(value)
     if 45 not in bits:
         return None
-    if 2 in bits or 3 in bits:
-        return "Resistance"
-    if 4 in bits:
-        return "PreheaterNegative"
-    if 5 in bits or 7 in bits:
-        return "NoiseGuard"
-    if 6 in bits or 8 in bits:
-        return "ResistanceGuard"
-    if 9 in bits:
-        return "FrostProtection"
-    if 10 in bits:
-        return "Bypass"
-    if 12 in bits:
-        return "AnalogInput1"
-    if 13 in bits:
-        return "AnalogInput2"
-    if 14 in bits:
-        return "AnalogInput3"
-    if 15 in bits:
-        return "AnalogInput4"
-    if 16 in bits:
-        return "Hood"
-    if 18 in bits:
-        return "AnalogPreset"
-    if 19 in bits:
-        return "ComfoCool"
-    if 22 in bits:
-        return "PreheaterPositive"
-    if 23 in bits:
-        return "RFSensorFlowPreset"
-    if 24 in bits:
-        return "RFSensorFlowProportional"
-    if 25 in bits:
-        return "TemperatureComfort"
-    if 26 in bits:
-        return "HumidityComfort"
-    if 27 in bits:
-        return "HumidityProtection"
-    if 47 in bits:
-        return "CO2ZoneX1"
-    if 48 in bits:
-        return "CO2ZoneX2"
-    if 49 in bits:
-        return "CO2ZoneX3"
-    if 50 in bits:
-        return "CO2ZoneX4"
-    if 51 in bits:
-        return "CO2ZoneX5"
-    if 52 in bits:
-        return "CO2ZoneX6"
-    if 53 in bits:
-        return "CO2ZoneX7"
-    if 54 in bits:
-        return "CO2ZoneX8"
 
-    return None
+    constraints = []
+    if 2 in bits or 3 in bits:
+        constraints.append("Resistance")
+    if 4 in bits:
+        constraints.append("PreheaterNegative")
+    if 5 in bits or 7 in bits:
+        constraints.append("NoiseGuard")
+    if 6 in bits or 8 in bits:
+        constraints.append("ResistanceGuard")
+    if 9 in bits:
+        constraints.append("FrostProtection")
+    if 10 in bits:
+        constraints.append("Bypass")
+    if 12 in bits:
+        constraints.append("AnalogInput1")
+    if 13 in bits:
+        constraints.append("AnalogInput2")
+    if 14 in bits:
+        constraints.append("AnalogInput3")
+    if 15 in bits:
+        constraints.append("AnalogInput4")
+    if 16 in bits:
+        constraints.append("Hood")
+    if 18 in bits:
+        constraints.append("AnalogPreset")
+    if 19 in bits:
+        constraints.append("ComfoCool")
+    if 22 in bits:
+        constraints.append("PreheaterPositive")
+    if 23 in bits:
+        constraints.append("RFSensorFlowPreset")
+    if 24 in bits:
+        constraints.append("RFSensorFlowProportional")
+    if 25 in bits:
+        constraints.append("TemperatureComfort")
+    if 26 in bits:
+        constraints.append("HumidityComfort")
+    if 27 in bits:
+        constraints.append("HumidityProtection")
+    if 47 in bits:
+        constraints.append("CO2ZoneX1")
+    if 48 in bits:
+        constraints.append("CO2ZoneX2")
+    if 49 in bits:
+        constraints.append("CO2ZoneX3")
+    if 50 in bits:
+        constraints.append("CO2ZoneX4")
+    if 51 in bits:
+        constraints.append("CO2ZoneX5")
+    if 52 in bits:
+        constraints.append("CO2ZoneX6")
+    if 53 in bits:
+        constraints.append("CO2ZoneX7")
+    if 54 in bits:
+        constraints.append("CO2ZoneX8")
+
+    return constraints

--- a/aiocomfoconnect/util.py
+++ b/aiocomfoconnect/util.py
@@ -19,6 +19,17 @@ def bytearray_to_bits(arr):
     return bits
 
 
+def uint_to_bits(value):
+    """Convert an unsigned integer to a list of set bits."""
+    bits = []
+    j = 0
+    for i in range(64):
+        if value & (1 << i):
+            bits.append(j)
+        j += 1
+    return bits
+
+
 def version_decode(version):
     """Decode the version number to a string."""
     v_1 = (version >> 30) & 3
@@ -46,3 +57,66 @@ def pdo_to_can(pdo, node_id=1):
 def can_to_pdo(can, node_id=1):
     """Convert a CAN-ID to a PDO-ID."""
     return (int(can, 16) - 0x40 - node_id) >> 14
+
+
+def calculate_airflow_constraint(value):
+    """Calculate the airflow constraint based on the bitshift value."""
+    bits = uint_to_bits(value)
+    if 45 not in bits:
+        return None
+    if 2 in bits or 3 in bits:
+        return "Resistance"
+    if 4 in bits:
+        return "PreheaterNegative"
+    if 5 in bits or 7 in bits:
+        return "NoiseGuard"
+    if 6 in bits or 8 in bits:
+        return "ResistanceGuard"
+    if 9 in bits:
+        return "FrostProtection"
+    if 10 in bits:
+        return "Bypass"
+    if 12 in bits:
+        return "AnalogInput1"
+    if 13 in bits:
+        return "AnalogInput2"
+    if 14 in bits:
+        return "AnalogInput3"
+    if 15 in bits:
+        return "AnalogInput4"
+    if 16 in bits:
+        return "Hood"
+    if 18 in bits:
+        return "AnalogPreset"
+    if 19 in bits:
+        return "ComfoCool"
+    if 22 in bits:
+        return "PreheaterPositive"
+    if 23 in bits:
+        return "RFSensorFlowPreset"
+    if 24 in bits:
+        return "RFSensorFlowProportional"
+    if 25 in bits:
+        return "TemperatureComfort"
+    if 26 in bits:
+        return "HumidityComfort"
+    if 27 in bits:
+        return "HumidityProtection"
+    if 47 in bits:
+        return "CO2ZoneX1"
+    if 48 in bits:
+        return "CO2ZoneX2"
+    if 49 in bits:
+        return "CO2ZoneX3"
+    if 50 in bits:
+        return "CO2ZoneX4"
+    if 51 in bits:
+        return "CO2ZoneX5"
+    if 52 in bits:
+        return "CO2ZoneX6"
+    if 53 in bits:
+        return "CO2ZoneX7"
+    if 54 in bits:
+        return "CO2ZoneX8"
+
+    return None

--- a/docs/PROTOCOL-PDO.md
+++ b/docs/PROTOCOL-PDO.md
@@ -88,7 +88,7 @@ Numbers are stored in little endian format.
 | 227  | CN_UINT8  | Bypass state                                     | value in % (100% = fully open)                                                                                   |
 | 228  | CN_UINT8  | ?? FrostProtectionUnbalance                      | 0                                                                                                                |
 | 229  | CN_BOOL   |                                                  | 1                                                                                                                |
-| 230  | CN_INT64  | Ventilation Constraints Bitset                   | See calculate_airflow_constraint()                                                                               |
+| 230  | CN_INT64  | Ventilation Constraints Bitset                   | See calculate_airflow_constraints()                                                                              |
 | 256  | CN_UINT8  |                                                  | 1=basic, 2=advanced, 3=installer                                                                                 |
 | 257  | CN_UINT8  |                                                  |                                                                                                                  |
 | 274  | CN_INT16  | Temperature: Extract Air                         | value in °C (171 -> 17.1 °C)                                                                                     |

--- a/docs/PROTOCOL-PDO.md
+++ b/docs/PROTOCOL-PDO.md
@@ -88,7 +88,7 @@ Numbers are stored in little endian format.
 | 227  | CN_UINT8  | Bypass state                                     | value in % (100% = fully open)                                                                                   |
 | 228  | CN_UINT8  | ?? FrostProtectionUnbalance                      | 0                                                                                                                |
 | 229  | CN_BOOL   |                                                  | 1                                                                                                                |
-| 230  | CN_INT64  | Ventilation Constraints Bitset                   |                                                                                                                  |
+| 230  | CN_INT64  | Ventilation Constraints Bitset                   | See calculate_airflow_constraint()                                                                               |
 | 256  | CN_UINT8  |                                                  | 1=basic, 2=advanced, 3=installer                                                                                 |
 | 257  | CN_UINT8  |                                                  |                                                                                                                  |
 | 274  | CN_INT16  | Temperature: Extract Air                         | value in °C (171 -> 17.1 °C)                                                                                     |


### PR DESCRIPTION
This PR adds parsing for PDO 230, what contains a bitshift list of airflow constraints.

Can be tested with:
```sh
$ python -m aiocomfoconnect show-sensor --host zehnder-bridge.lan 230 -f
```

Note that the APP has a logic to only show one value (the first that it found). I'll add this logic in the home-assistant integration.