### PR TITLE
Add ComfoCool state and condensor temperature sensors mappings

### DIFF
--- a/aiocomfoconnect/sensors.py
+++ b/aiocomfoconnect/sensors.py
@@ -74,6 +74,8 @@ SENSOR_TEMPERATURE_OUTDOOR = 276
 SENSOR_TEMPERATURE_SUPPLY = 221
 SENSOR_UNIT_AIRFLOW = 224
 SENSOR_UNIT_TEMPERATURE = 208
+SENSOR_COMFOCOOL_STATE = 784
+SENSOR_COMFOCOOL_CONDENSOR_TEMP = 802
 
 UNIT_WATT = "W"
 UNIT_KWH = "kWh"
@@ -179,7 +181,7 @@ SENSORS: Dict[int, Sensor] = {
     SENSOR_COMFOFOND_TEMP_GROUND: Sensor("ComfoFond Ground Temperature", None, 417, PdoType.TYPE_CN_INT16, lambda x: x / 10),
     SENSOR_COMFOFOND_GHE_STATE: Sensor("ComfoFond GHE State Percentage", None, 418, PdoType.TYPE_CN_UINT8),
     SENSOR_COMFOFOND_GHE_PRESENT: Sensor("ComfoFond GHE Present", None, 419, PdoType.TYPE_CN_BOOL, bool),
-    784: Sensor("sensor_784", None, 784, PdoType.TYPE_CN_UINT8),
+    SENSOR_COMFOCOOL_STATE: Sensor("ComfoCool State", None, 784, PdoType.TYPE_CN_UINT8),
     785: Sensor("sensor_785", None, 785, PdoType.TYPE_CN_BOOL),
-    802: Sensor("sensor_802", None, 802, PdoType.TYPE_CN_INT16, lambda x: x / 10),
+    SENSOR_COMFOCOOL_CONDENSOR_TEMP: Sensor("ComfoCool Condensor Temperature", None, 802, PdoType.TYPE_CN_INT16, lambda x: x / 10),
 }

--- a/docs/PROTOCOL-PDO.md
+++ b/docs/PROTOCOL-PDO.md
@@ -145,7 +145,7 @@ Numbers are stored in little endian format.
 | 522  | CN_INT16  |                                                  |                                                                                                                  |
 | 523  | CN_INT16  |                                                  |                                                                                                                  |
 | 524  | CN_UINT8  |                                                  |                                                                                                                  |
-| 784  | CN_UINT8  |                                                  | 0=off, 1=on (0)                                                                                                  |
+| 784  | CN_UINT8  | ComfoCool State                                  | 0=off, 1=on (0)                                                                                                  |
 | 785  | CN_BOOL   | ?? ComfoCoolCompressor State                     | 0                                                                                                                |
 | 801  | CN_INT16  | ?? T10ROOMTEMPERATURE                            | 0.0                                                                                                              |
 | 802  | CN_INT16  | ComfoCool Condensor Temperature                  | 0.0                                                                                                              |


### PR DESCRIPTION
Like in app state for comfocool is 0 == OFF and 1 == ON

```
python3 -m aiocomfoconnect show-sensors --host 182.168.1.34
                         ComfoCool State: 0
                              sensor_785: 0
         ComfoCool Condensor Temperature: 24.2
```
![IMG_0874](https://github.com/michaelarnauts/aiocomfoconnect/assets/329831/4a13e29f-56cc-4ab2-ba7e-a68066fc4a17)

and for comfocool running
```
                         ComfoCool State: 1
                              sensor_785: 0
         ComfoCool Condensor Temperature: 44.0
```
![IMG_0875](https://github.com/michaelarnauts/aiocomfoconnect/assets/329831/b57b1ff9-5469-4a5c-92c3-d3c8701b09ea)

