### PR TITLE
Fix unholding sensors that don't have a value

### DIFF
--- a/aiocomfoconnect/comfoconnect.py
+++ b/aiocomfoconnect/comfoconnect.py
@@ -67,8 +67,8 @@ class ComfoConnect(Bridge):
 
         # Emit the current cached values of the sensors, by now, they should have received a correct update.
         for sensor_id, _ in self._sensors.items():
-            if self._sensors_values[sensor_id] is not None:
-                self._sensor_callback(sensor_id, self._sensors_values[sensor_id])
+            if self._sensors_values.get(sensor_id) is not None:
+                self._sensor_callback(sensor_id, self._sensors_values.get(sensor_id))
 
     async def connect(self, uuid: str):
         """Connect to the bridge."""


### PR DESCRIPTION
This fixes the error where the library would try to release hold sensor updates that didn't have a value yet:

See https://github.com/michaelarnauts/home-assistant-comfoconnect/issues/62#issuecomment-2223699396

This probably caused some disconnection issues