### PR TITLE
fix _connect hang when not registered device

### DIFF
--- a/aiocomfoconnect/comfoconnect.py
+++ b/aiocomfoconnect/comfoconnect.py
@@ -33,6 +33,7 @@ from aiocomfoconnect.const import (
 from aiocomfoconnect.exceptions import (
     AioComfoConnectNotConnected,
     AioComfoConnectTimeout,
+    ComfoConnectNotAllowed,
 )
 from aiocomfoconnect.properties import Property
 from aiocomfoconnect.sensors import Sensor
@@ -112,6 +113,11 @@ class ComfoConnect(Bridge):
                 except AioComfoConnectNotConnected:
                     # Reconnect when connection has been dropped
                     _LOGGER.info("We got disconnected. Reconnecting.")
+
+                except ComfoConnectNotAllowed as exception:
+                    # Passthrough exception if not allowed (because not registered uuid for example )
+                    connected.set_exception(exception)
+                    return
 
         reconnect_task = self._loop.create_task(_reconnect_loop())
         self._tasks.add(reconnect_task)


### PR DESCRIPTION
Thanks for this project! I found this when trying to implement control over my ventilation via Google Home and this is very helpful.
While running `aiocomfoconnect register` it hangs on my machine.
I think this is bug introduced while implementing reconnect logic.
When exception ComfoConnectNotAllowed is thrown, it will be dropped and `await connected` will hang until time out. 
And then code
```
except ComfoConnectNotAllowed:
        # We probably are not registered yet...
        try:
            await comfoconnect.cmd_register_app(uuid, name, pin)
```
will not be executed, so app will never register.
After this fix I can register and use this module properly.