### PR TITLE
Add entrypoint for the aiocomfoconnect cli

### DIFF
--- a/aiocomfoconnect/__main__.py
+++ b/aiocomfoconnect/__main__.py
@@ -389,7 +389,8 @@ async def run_set_flow_for_speed(host: str, uuid: str, speed: Literal["away", "l
     await comfoconnect.disconnect()
 
 
-if __name__ == "__main__":
+def main_cli():
+    """Parse arguments and start async event loop."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", "-d", help="Enable debug logging", default=False, action="store_true")
     subparsers = parser.add_subparsers(required=True, dest="action")
@@ -472,3 +473,7 @@ if __name__ == "__main__":
         asyncio.run(main(arguments), debug=True)
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == "__main__":
+    main_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = ["Michaël Arnauts <michael.arnauts@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/michaelarnauts/aiocomfoconnect"
 
+[tool.poetry.scripts]
+aiocomfoconnect = "aiocomfoconnect.__main__:main_cli"
+
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "^3.8.0"


### PR DESCRIPTION
This adds the cli as entrypoint. This will allow you to install the cli using `uv tool install  aiocomfoconnect` or run it directly with `uvx aiocomfoconnect`.